### PR TITLE
Add additional content sections to press kit

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,17 @@
         .section {
             margin-bottom: 40px;
         }
+        .media-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+            gap: 20px;
+            margin: 20px 0;
+        }
+        .media-placeholder {
+            background: #f0f0f0;
+            padding: 20px;
+            text-align: center;
+        }
     </style>
 </head>
 <body>
@@ -32,8 +43,60 @@
     </div>
 
     <div class="section">
+        <h2>Key Features</h2>
+        <ul>
+            <li>Unique gameplay mechanics utilizing the Playdate's crank control</li>
+            <li>Distinctive black and white art style</li>
+            <li>Engaging story-driven experience</li>
+            <li>Original soundtrack</li>
+            <li>Multiple game modes</li>
+        </ul>
+    </div>
+
+    <div class="section">
+        <h2>Screenshots & Media</h2>
+        <div class="media-grid">
+            <div class="media-placeholder">[Screenshot 1]</div>
+            <div class="media-placeholder">[Screenshot 2]</div>
+            <div class="media-placeholder">[Screenshot 3]</div>
+        </div>
+    </div>
+
+    <div class="section">
+        <h2>Technical Requirements</h2>
+        <ul>
+            <li>Platform: Playdate</li>
+            <li>Storage: [Size] MB</li>
+            <li>Operating System: Playdate OS [version]</li>
+        </ul>
+    </div>
+
+    <div class="section">
+        <h2>Release Information</h2>
+        <p>Release Date: [TBA]<br>
+Price: [Price]<br>
+Availability: Playdate Store</p>
+    </div>
+
+    <div class="section">
         <h2>Development</h2>
         <p>The game has been developed with careful attention to the unique features of the Playdate, including its distinctive black and white display and crank mechanism. The development journey has been documented on the Playdate Developer Forum, showing the evolution of the game from concept to reality.</p>
+    </div>
+
+    <div class="section">
+        <h2>Team & Credits</h2>
+        <ul>
+            <li>Game Design: [Name]</li>
+            <li>Programming: [Name]</li>
+            <li>Art: [Name]</li>
+            <li>Sound Design: [Name]</li>
+            <li>Music: [Name]</li>
+        </ul>
+    </div>
+
+    <div class="section">
+        <h2>Press Coverage & Reviews</h2>
+        <p>[To be added as reviews become available]</p>
     </div>
 
     <div class="section">


### PR DESCRIPTION
This PR addresses issue #1 by adding the following sections to the press kit:

- Screenshots/Media section with placeholder images
- Key Features list highlighting game mechanics and style
- Technical Requirements section
- Release Information
- Team/Credits section
- Press Coverage/Reviews section (placeholder)

The layout has been enhanced with a grid system for media content and improved styling for better readability.